### PR TITLE
Schema improvements (tentative)

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -1,5 +1,5 @@
 {
-    "Project":{
+    "Project": {
         "id": {
             "type":"int"
         },
@@ -16,7 +16,7 @@
             "description": "A score representing how 'innovative' the project is, between 0 (least innovative) and 1 (most innovative). This attribute is liable to change as more sophisticated project innovation metrics are developed."
         },
         "pub_med_uids": {
-            "type": "int array",
+            "type": "int[]",
             "description": "Unique IDs associated with articles on PubMed."
         },
         "source": {
@@ -28,32 +28,28 @@
             "description": "The amount awarded to the project (in USD?)"
         },
         "institutions": {
-            "type": "relationship Institute['id'] array",
+            "type": "<ResearchInstitution.id>[]",
             "description": "All of the institutions mentioned in the body text of the project."
         },
         "funder": {
-            "type": "relationship Funder['id']",
+            "type": "<Funder.id>[]",
             "description": "The main funding body for the project as identified in the original data."
         },
         "mesh_labels": {
-            "type": "relationship MeshLabel['id'] array",
+            "type": "<MeshLabel.id>[]",
             "description": "The MeSH labels that have been associated with the body text of the project."
         }
     },
-    "Term":{
+    "Term": {
         "id": {
-            "type": "int"
-        },
-        "name": {
-            "type": "str",
-            "description": "Lowercase text of the term."
+            "type": "<MeshLabel.id>"
         },
         "count": {
             "type": "int",
             "description": "Number of times that the term has occured in the corpus of project descriptions."
         }
     },
-    "ResearchInstitution":{
+    "ResearchInstitution": {
         "id": {
             "type": "int"
         },
@@ -61,20 +57,22 @@
             "type": "str",
             "description": "Name of research institution."
         },
-        "latitude": {
-            "type": "float"
+        "location": {
+            "type": "<Location.id>",
+            "description": "Location of the institution."
         },
-        "longitude": {
-            "type": "float"
+        "country": {
+            "type": "<Country.id>",
+            "description": "The country of the institution."
         }
     },
-    "TermCooccurrence":{
+    "TermCooccurrence": {
         "term_0": {
-            "type": "relationship Term['id']",
+            "type": "<Term.id>",
             "description": "The first term of the cooccurring pair when sorted alphabetically."
         },
         "term_1": {
-            "type": "relationship Term['id']",
+            "type": "<Term.id>",
             "description": "The second term of the coocurring pair when sorted alphabetically."
         },
         "association_strength": {
@@ -86,16 +84,13 @@
             "description": "Raw count of coocurrences"
         }
     },
-    "ProjectCoocurrence":{
-        "id": {
-            "type": "int"
-        },
+    "ProjectOverlap": {
         "project_0": {
-            "type": "relationship Project['id']",
+            "type": "<Project.id>",
             "description": "The first project of the cooccurring pair when sorted by Project ID."
         },
         "project_1": {
-            "type": "relationship Project['id']",
+            "type": "<Project.id>",
             "description": "The second project of the cooccurring pair when sorted by Project ID."
         },
         "jaccard_similarity": {
@@ -103,7 +98,7 @@
             "description": "A measure of similarity between two projects based on the overlap of the MeSH terms that they have been labelled with."
         }
     },
-    "Country":{
+    "Country": {
         "id": {
             "type": "int"
         },
@@ -116,12 +111,31 @@
             "description": "The official ISO 3 country code."
         }
     },
-    "MeshLabel":{
-        "id": "int",
-        "name": "str",
-        "mesh_tree_number": "str"
+    "Location": {
+        "id": {
+            "type": "int",
+            "description": "Useful to identity overlapping items."
+        },
+        "latitude": {
+            "type": "float"
+        },
+        "longitude": {
+            "type": "float"
+        },
     },
-    "Funder":{
+    "MeshLabel": {
+        "id": {
+            "type": "int"
+        },
+        "name": {
+            "type": "str",
+            "description": "Lowercase text of the term."
+        },
+        "mesh_tree_number": {
+            "type": "str"
+        },
+    },
+    "Funder": {
         "id": {
             "type": "int"
         },
@@ -130,8 +144,12 @@
             "description": "Name of the funding body."
         },
         "country": {
-            "type": "relationship Country['id']",
+            "type": "<Country.id>",
             "description": "The country in which the funding body is based."
+        },
+        "location": {
+            "type": "<Location.id>",
+            "description": "Location of the funder."
         }
     }
 }


### PR DESCRIPTION
- added a Location type, with id, so that we can easily identify institutions and funders in the same building (may happen b/c of hubs and accelerators or same building hosting different insitutios maybe)
- using a notation for types that seems more readable (e.g. "<Funder.id>[]")
- a Term.id should maybe be <MeshLabel.id>?
- added a location to the Funder type